### PR TITLE
Docs/51/deletecards deck

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -206,7 +206,29 @@ paths:
         in: query
         required: true
         type: string
-
+    delete:
+      operationId: deleteCardsFromDeck
+      description: Delete the specified cards from a deck
+      parameters:
+        - $ref: '#/parameters/access_token'
+      responses:
+        '200':
+          description: Specified cards deleted from the deck
+          schema:
+            type: string
+            example: 1
+        '400':
+          description: The JSON body is invalid
+          schema:
+            $ref: '#/definitions/RestErr'
+        '404':
+          description: The specified deck does not exist, invalid deckID
+          schema:
+            $ref: '#/definitions/RestErr'
+        '500':
+          description: Failed to update the cards list
+          schema:
+            $ref: '#/definitions/RestErr'
   /card:
     post:
       consumes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -200,6 +200,13 @@ paths:
           description: Something failed while patching
           schema:
             $ref: '#/definitions/RestErr'
+  /deck/{deckID}/cards:
+    parameters:
+      - name: deckID
+        in: query
+        required: true
+        type: string
+
   /card:
     post:
       consumes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -229,6 +229,29 @@ paths:
           description: Failed to update the cards list
           schema:
             $ref: '#/definitions/RestErr'
+    patch:
+      operationId: updateDeckCards
+      description: Updates the specified cards from a deck
+      parameters:
+        - $ref: '#/parameters/access_token'
+      responses:
+        '200':
+          description: Deck deleted
+          schema:
+            type: string
+            example: deck deleted
+        '400':
+          description: The JSON body is invalid
+          schema:
+            $ref: '#/definitions/RestErr'
+        '404':
+          description: The specified deck does not exist, invalid deckID
+          schema:
+            $ref: '#/definitions/RestErr'
+        '500':
+          description: Failed to update the cards list
+          schema:
+            $ref: '#/definitions/RestErr'
   /card:
     post:
       consumes:


### PR DESCRIPTION
Documented `/deck/{deckID}/cards` endpoints for `PATCH`, `DELETE` methods.